### PR TITLE
feat(Sequencing): implemented notion of 'task' and seuqenced needed tasks for SRG failure analysis

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,3 +9,9 @@ exclude =
 indent-size = 2
 max-line-length = 160
 max-complexity = 10
+
+# Explanation section:
+# E203: Whitespace before ':'
+#   This is recommended by black in relation to slice formatting.
+# E731: do not assign a lambda expression, use a def
+#   I think this is lame, anonymous functions can be good if used intentionally

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ bin/*
 include/*
 lib*
 pyvenv.cfg
-__pycache__/*
+*__pycache__*
 *.txt

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ run:
 
 .PHONY: request_reading
 request_reading:
-	@source bin/activate && python3 testClient.py -m PERFORM_READING
+	@source bin/activate && python3 testClient.py -m 0
 
 .PHONY: transfer_working_files
 transfer_working_files:
@@ -26,3 +26,7 @@ transfer_working_files:
 .PHONY: flake8
 flake8:
 	@python3 -m flake8 || true
+
+.PHONY: test
+test:
+	@source bin/activate && pytest tests/Test*.py

--- a/README.md
+++ b/README.md
@@ -30,16 +30,16 @@ To simplify the user interactions we are codifying normal steps in the Makefile.
 - `make request_reading`- spawns an instance of the client and specifically requests a reading be performed by server
 - `make transfer_working_files` - rsyncs working files to development machine `psbuild-rhel7`, if FTPUSER not definded defaults to `joshc`
 - `make flake8` - will lint the project, please do so!
+- `make test` - will run all unit tests in the `tests/` directory, please do so!
 
-Pedantic note: this should all be dockerized why wont they let me run docker on prod tools.
+Pedantic note: this should all be dockerized why wont they let me run docker on prod tools, TID seemingly gets too...
 
 ## Note that no besides Josh cares about
 This would all be a million times better in gods programming langauge c++ todo port 
 ### TODOS:
-- [ ] integrate flake8 into make file
-
+- [ ] Increase unit test coverage please
+- [ ] Typify please
 - [ ] make TCP server more legit or switch to GRPC (or just protobuf over tcp...)
-- [ ] Formalize (as far as python allows) notion of job queue, what is a job in python? Potentially use a python "wrapper" to anonymize these functions for job queue purposes
 - [ ] add spdlog or our epics logging environment
 - [ ] Formalize / unify pyepics interactions to be consistent with the rest of our codebase (if that consistency exists)
 - [ ] Mourn at the alter of c++ i will return just you wait

--- a/Task.py
+++ b/Task.py
@@ -1,0 +1,44 @@
+import threading
+from enum import IntEnum
+from typing import Callable
+
+
+class TaskState(IntEnum):
+  NOT_STARTED = 0
+  RUNNING = 1
+  COMPLETE = 2
+  FAILED = -1
+
+
+class Task():
+  '''
+  Generic Task class
+  '''
+  def __init__(self, task_name: str, work_function: Callable[..., bool]) -> None:
+    self.__state__ = TaskState.NOT_STARTED
+    self.__task_name__ = task_name
+    self.__work_function__ = work_function
+    self.__work_thread__ = None
+
+  def start(self) -> None:
+    self.__work_thread__ = threading.Thread(target=self.__work_function__)  # TODO(josh): pass kwargs, likely cvs
+    print(f"INFO: Starting job: {self.__task_name__}")
+    self.__work_thread__.start()  # TODO (josh): wrap in try catch, return boolean based on success
+    self.__state__ = TaskState.RUNNING  
+
+  def stop(self) -> None:
+    print(f"INFO: Stopping job: {self.__task_name__}")
+    self.__work_thread__.join()  # TODO (josh): wrap in try catch (with timeout), return boolean based on success
+    print(f"INFO: {self.__task_name__} joined")
+    self.__state__ = TaskState.COMPLETE
+
+  def get_state(self) -> TaskState:
+    return self.__state__
+
+
+if __name__ == "__main__":
+  call = lambda: True
+  task = Task(task_name="test1",
+              work_function=call)
+  task.start()
+  task.stop()

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .Task import Task

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "srg_failure_tester"
+version = "0.0.1"
+authors = [
+  { name="Josh Cohen", email="joshc@slac.stanford.edu" },
+]
+description = "Spherical Rotor Gauge Tester"
+readme = "README.md"
+requires-python = ">=3.6"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]

--- a/rsync-file-list
+++ b/rsync-file-list
@@ -2,5 +2,6 @@ RequestServer.py
 testClient.py
 SRGTester.py
 SRGTesterJobs.py
+Task.py
 Makefile
 requirements.txt

--- a/tests/TestTask.py
+++ b/tests/TestTask.py
@@ -1,0 +1,26 @@
+from typing import Callable
+
+from ..Task import Task, TaskState
+
+
+class TestTask:
+  def test_task_state_cycle(self):
+      """
+      Test TaskState lifecycle
+      """
+      call = lambda: True
+      print(f"call is callable {isinstance(call, Callable)}")
+      task = Task(task_name="test1",
+                  work_function=call)
+      assert task.get_state() == TaskState.NOT_STARTED
+      task.start()
+      assert task.get_state() == TaskState.RUNNING
+      task.stop()
+      assert task.get_state() == TaskState.COMPLETE
+
+  def test_two(self):
+    # While I have no love for meaningless commited code
+    # Let this serve as an ugly reminder to actually enable these Tasks to communicate between
+    # One another and to unit test that functionality here
+    self.value = 2
+    assert self.value == 2


### PR DESCRIPTION
## Description:
Previous PRs implemented the base needed functionality:
* acquire telnet shell to persist logs of interaction
* inject request to zero SRG in the EPICS layer
* monitor functionality critical PVs within the SRG on a given time horizon
* evaluate success of given run (**not implemented**)

This PR implements:
* ability to sequence those tasks relative to one another
* correcting some bugs introduced by PR #2 
* enabling unit testing 

## TODOs:
- StrEnum isn't supported in prod python version (3.6.8). Either get IT to enable me to pip install on these prod machines or just switch to protobuf. Use case is general deserialization things
- Tasks are sequenced *very* naively at the moment. Enable cross talk between tasks either with thread.Events, thread.Conditions, or add `follows()` / `is_ready()` relationship.  