### PR TITLE
feat(EvaluateRun): enabled application to discern between a successful and failed run and to store artifact files accordingly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ lib*
 pyvenv.cfg
 *__pycache__*
 *.txt
+*.csv
+temp/*
+succ/*
+fail/*

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ setup:
 	else \
 		@python3 -m venv . ; \
 	fi
+	@mkdir temp succ fail
 
 .PHONY: run
 run:

--- a/SRGTester.py
+++ b/SRGTester.py
@@ -29,7 +29,7 @@ class SrgTester:
     self.cv = threading.Condition()
     self.req_serv = RequestServer(self.cv)
     self.message_thread = threading.Thread(target=self.mess_thread, args=(self.cv,))
-    self.work_queue = []  # work queue of anonymous functions void(void)
+    self.work_queue = []  # work queue of anonymous functions void(void) #TODO make this of type queue from the queue lib
 
     self.do_work = False
     self.work_thread = threading.Thread(target=self.work_thread, args=())


### PR DESCRIPTION
## Description
Enabled the binning of results into `succ` and `fail` folders to allow for procedural debugging of the original serial interface issue

added a command to `make setup` to create needed folders (the program should handle this automatically but I'm lazy)
## TODO
make it such that when the client invokes a read we name the file something like the minute that it gets invoked (anything for a unique file name)